### PR TITLE
Removing rdfextra imports, correcting indentation

### DIFF
--- a/libvocab.py
+++ b/libvocab.py
@@ -52,11 +52,6 @@ from rdflib import term
 from rdflib.namespace import Namespace
 from rdflib.graph import Graph, ConjunctiveGraph
 
-rdflib.plugin.register('sparql', rdflib.query.Processor,
-	'rdfextras.sparql.processor', 'Processor')
-rdflib.plugin.register('sparql', rdflib.query.Result,
-	'rdfextras.sparql.query', 'SPARQLQueryResult')
-
 import datetime
 
 # pre3: from rdflib.sparql.sparqlGraph  import SPARQLGraph

--- a/specgen6.py
+++ b/specgen6.py
@@ -170,9 +170,9 @@ def main():
       
   # check we have benn given an ontology file
   if (ontofile == None or len(ontofile)==0):
-  	print "No ontology file given"
-        usage()
-        sys.exit(2)
+      print "No ontology file given"
+      usage()
+      sys.exit(2)
   else:
   	print "Use ontology file ",ontofile    
 


### PR DESCRIPTION
I have removed rdfextras sparql plugin. SPARQL is now core in rdflib, and they actually create a conflict (See https://github.com/RDFLib/rdflib/issues/435). Also corrected indentation problem mentioned in https://github.com/specgen/specgen/issues/15.